### PR TITLE
Update Copilot suggestion color

### DIFF
--- a/chadrc.lua
+++ b/chadrc.lua
@@ -12,6 +12,9 @@ M.base46 = {
         -- lighter grey-blue taken from Catppuccin “overlay2” (#a6adc8)
         Comment = { fg = "#a6adc8", italic = true },
         ["@comment"] = { fg = "#a6adc8", italic = true }, -- Treesitter alias
+
+        -- Copilot's ghost text should be faint but not identical to comments
+        CopilotSuggestion = { fg = "#7f849c", italic = true },
     },
 }
 


### PR DESCRIPTION
## Summary
- tweak `CopilotSuggestion` highlight so ghost text isn't identical to comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687167c01960832c8692b24051ae6ff7