### PR TITLE
Update Copilot suggestion color

### DIFF
--- a/chadrc.lua
+++ b/chadrc.lua
@@ -12,6 +12,9 @@ M.base46 = {
         -- lighter grey-blue taken from Catppuccin “overlay2” (#a6adc8)
         Comment = { fg = "#a6adc8", italic = true },
         ["@comment"] = { fg = "#a6adc8", italic = true }, -- Treesitter alias
+
+        -- Copilot's ghost text should be faint but still distinguishable
+        CopilotSuggestion = { fg = "#6c7086", italic = true },
     },
 }
 

--- a/plugins/init.lua
+++ b/plugins/init.lua
@@ -191,6 +191,17 @@ return {
                 },
             })
 
+            -- Ensure Copilot suggestions use a subtle color distinct from comments
+            local function set_copilot_hl()
+                vim.api.nvim_set_hl(0, "CopilotSuggestion", { fg = "#6c7086", italic = true })
+            end
+            set_copilot_hl()
+
+            -- reapply highlight after colorscheme changes
+            vim.api.nvim_create_autocmd("ColorScheme", {
+                callback = set_copilot_hl,
+            })
+
             -- Toggle (<leader>ct) still handy
             vim.keymap.set("n", "<leader>ct", function()
                 if vim.b.copilot_enabled == false then


### PR DESCRIPTION
## Summary
- highlight Copilot suggestion with a darker shade so it isn't identical to comment text
- set highlight at runtime when Copilot loads
- ensure highlight persists across colorscheme changes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687167c01960832c8692b24051ae6ff7