### PR TITLE
Add snacks.nvim with git utilities

### DIFF
--- a/configs/snacks.lua
+++ b/configs/snacks.lua
@@ -1,0 +1,75 @@
+local M = {}
+
+-- Snacks configuration for NvChad
+-- Only enable the modules that are useful for this setup.
+
+-- Git helper utilities
+-- - `<leader>gb` opens a floating window showing `git blame` information for the
+--   current line.
+M.git = {
+    enabled = true,
+}
+
+-- Indent guides and scope lines. Useful for Python's indentation based blocks.
+-- Toggle on/off with `<leader>ti` (see `mappings.lua`).
+M.indent = {
+    enabled = true,
+}
+
+-- Toggleable floating/split terminal.
+-- Mapped to `<leader>tt` for quick access.
+M.terminal = {
+    enabled = true,
+}
+
+-- Highlight LSP references and jump between them.
+-- Disabled by default. Uncomment the keymaps in `mappings.lua` to use.
+M.words = {
+    enabled = false,
+}
+
+-- Disable the rest of Snacks features to keep the setup minimal.
+-- bigfile    : skips heavy plugins for huge files
+M.bigfile = { enabled = false }
+-- dashboard  : simple start screen on launch
+M.dashboard = { enabled = false }
+-- explorer   : minimal file explorer
+M.explorer = { enabled = false }
+-- input      : nicer vim.ui.input prompts
+M.input = { enabled = false }
+-- picker     : fuzzy item picker
+M.picker = { enabled = false }
+-- notifier   : better vim.notify UI
+M.notifier = { enabled = false }
+-- quickfile  : speed up startup when opening a file directly
+M.quickfile = { enabled = false }
+-- scope      : textobject-based scope jumping
+M.scope = { enabled = false }
+-- scroll     : smooth scrolling animations
+M.scroll = { enabled = false }
+-- statuscolumn: custom status column
+M.statuscolumn = { enabled = false }
+-- toggle     : create user toggles integrated with which-key
+M.toggle = { enabled = false }
+-- gitbrowse  : open files or commits on GitHub
+M.gitbrowse = { enabled = false }
+-- layout     : window layout utilities
+M.layout = { enabled = false }
+-- lazygit    : open lazygit in a float
+M.lazygit = { enabled = false }
+-- rename     : rename files with LSP integration
+M.rename = { enabled = false }
+-- scratch    : simple scratch buffers
+M.scratch = { enabled = false }
+-- profiler   : profile lua code
+M.profiler = { enabled = false }
+-- dim        : dim inactive windows
+M.dim = { enabled = false }
+-- image      : preview images using kitty graphics
+M.image = { enabled = false }
+-- win        : window helpers for floats/splits
+M.win = { enabled = false }
+-- zen        : distraction-free coding mode
+M.zen = { enabled = false }
+
+return M

--- a/mappings.lua
+++ b/mappings.lua
@@ -45,3 +45,20 @@ map("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "move block up" })
 --     --  alternative Trouble view (uncomment if you prefer):
 --     -- require("trouble").toggle("lsp_references")
 -- end, { desc = "LSP: list references" })
+
+-- Snacks.nvim
+map("n", "<leader>gb", function()
+  require("snacks.git").blame_line()
+end, { desc = "Git blame current line" })
+
+map("n", "<leader>tt", function()
+  require("snacks.terminal").toggle()
+end, { desc = "Toggle terminal" })
+
+map("n", "<leader>ti", function()
+  require("snacks.toggle").indent()
+end, { desc = "Toggle indent guides" })
+
+-- Jump between LSP references when Snacks.words is enabled
+-- map("n", "]]", function() require("snacks.words").jump(1) end, { desc = "Next reference" })
+-- map("n", "[[", function() require("snacks.words").jump(-1) end, { desc = "Prev reference" })

--- a/plugins/init.lua
+++ b/plugins/init.lua
@@ -15,6 +15,15 @@ return {
             return {}
         end,
     },
+    {
+        "folke/snacks.nvim",
+        lazy = false,
+        priority = 1000,
+        config = function()
+            require("snacks").setup(require("configs.snacks"))
+        end,
+    },
+
     -----------------------------------------------------------------
     -- nvim-tree: auto-open when Neovim starts with no file,
     --            auto-quit if it’s the last window


### PR DESCRIPTION
## Summary
- enable `folke/snacks.nvim` for git blame and useful utilities
- document and configure enabled/disabled snacks
- provide keymaps for git blame, terminal toggle and indent toggle

## Testing
- `nvim --version`

------
https://chatgpt.com/codex/tasks/task_e_68714645c9d4832c8b190e6857d7c181